### PR TITLE
Correct PolicyEndpoint matching_target enum

### DIFF
--- a/pkg/unifi/builders.go
+++ b/pkg/unifi/builders.go
@@ -159,7 +159,8 @@ func (b *PolicyEndpointBuilder) ZoneID(id string) *PolicyEndpointBuilder {
 	return b
 }
 
-// MatchingTarget sets the matching target type (ANY, APP, APP_CATEGORY, IP, IID, NETWORK, REGION, WEB).
+// MatchingTarget sets the matching target (ANY, APP, APP_CATEGORY, IP, IID, NETWORK, REGION, WEB).
+// For the SPECIFIC vs OBJECT companion, see MatchingTargetType.
 func (b *PolicyEndpointBuilder) MatchingTarget(target string) *PolicyEndpointBuilder {
 	b.endpoint.MatchingTarget = target
 	return b

--- a/pkg/unifi/builders.go
+++ b/pkg/unifi/builders.go
@@ -159,7 +159,7 @@ func (b *PolicyEndpointBuilder) ZoneID(id string) *PolicyEndpointBuilder {
 	return b
 }
 
-// MatchingTarget sets the matching target type (ANY, IP, NETWORK, DOMAIN, REGION, PORT_GROUP, ADDRESS_GROUP).
+// MatchingTarget sets the matching target type (ANY, APP, APP_CATEGORY, IP, IID, NETWORK, REGION, WEB).
 func (b *PolicyEndpointBuilder) MatchingTarget(target string) *PolicyEndpointBuilder {
 	b.endpoint.MatchingTarget = target
 	return b

--- a/pkg/unifi/network_models.go
+++ b/pkg/unifi/network_models.go
@@ -648,7 +648,7 @@ type FirewallPolicy struct {
 // PolicyEndpoint defines source or destination matching criteria for a firewall policy.
 //
 // Field value reference:
-//   - MatchingTarget: "ANY", "IP", "NETWORK", "DOMAIN", "REGION", "PORT_GROUP", "ADDRESS_GROUP"
+//   - MatchingTarget: "ANY", "APP", "APP_CATEGORY", "IP", "IID", "NETWORK", "REGION", "WEB"
 //   - MatchingTargetType: "SPECIFIC", "OBJECT"
 //   - PortMatchingType: "ANY", "SPECIFIC"
 type PolicyEndpoint struct {
@@ -668,8 +668,8 @@ type PolicyEndpoint struct {
 
 // Validate checks that PolicyEndpoint fields have valid values.
 func (p *PolicyEndpoint) Validate() error {
-	if p.MatchingTarget != "" && !isOneOf(p.MatchingTarget, "ANY", "IP", "NETWORK", "DOMAIN", "REGION", "PORT_GROUP", "ADDRESS_GROUP") {
-		return fmt.Errorf("policyendpoint: matching_target must be one of: ANY, IP, NETWORK, DOMAIN, REGION, PORT_GROUP, ADDRESS_GROUP")
+	if p.MatchingTarget != "" && !isOneOf(p.MatchingTarget, "ANY", "APP", "APP_CATEGORY", "IP", "IID", "NETWORK", "REGION", "WEB") {
+		return fmt.Errorf("policyendpoint: matching_target must be one of: ANY, APP, APP_CATEGORY, IP, IID, NETWORK, REGION, WEB")
 	}
 	if p.MatchingTargetType != "" && !isOneOf(p.MatchingTargetType, "SPECIFIC", "OBJECT") {
 		return fmt.Errorf("policyendpoint: matching_target_type must be one of: SPECIFIC, OBJECT")

--- a/pkg/unifi/network_models_test.go
+++ b/pkg/unifi/network_models_test.go
@@ -527,7 +527,20 @@ func TestPolicyEndpointValidate(t *testing.T) {
 		{"valid matching target ANY", PolicyEndpoint{MatchingTarget: "ANY"}, ""},
 		{"valid matching target IP", PolicyEndpoint{MatchingTarget: "IP"}, ""},
 		{"valid matching target NETWORK", PolicyEndpoint{MatchingTarget: "NETWORK"}, ""},
+		{"valid matching target REGION", PolicyEndpoint{MatchingTarget: "REGION"}, ""},
+		{"valid matching target APP", PolicyEndpoint{MatchingTarget: "APP"}, ""},
+		{"valid matching target APP_CATEGORY", PolicyEndpoint{MatchingTarget: "APP_CATEGORY"}, ""},
+		{"valid matching target IID", PolicyEndpoint{MatchingTarget: "IID"}, ""},
+		{"valid matching target WEB", PolicyEndpoint{MatchingTarget: "WEB"}, ""},
 		{"invalid matching target", PolicyEndpoint{MatchingTarget: "INVALID"}, "matching_target must be one of"},
+		// The following values were once accepted by an earlier version of this
+		// SDK's validator, but were never accepted by the v9 controller's actual
+		// enum. A direct probe returned the canonical list:
+		// [APP, WEB, IP, APP_CATEGORY, NETWORK, IID, ANY, REGION]. These cases
+		// guard against re-introducing the wrong enum values in a future change.
+		{"rejected legacy DOMAIN", PolicyEndpoint{MatchingTarget: "DOMAIN"}, "matching_target must be one of"},
+		{"rejected legacy PORT_GROUP", PolicyEndpoint{MatchingTarget: "PORT_GROUP"}, "matching_target must be one of"},
+		{"rejected legacy ADDRESS_GROUP", PolicyEndpoint{MatchingTarget: "ADDRESS_GROUP"}, "matching_target must be one of"},
 		{"valid matching target type SPECIFIC", PolicyEndpoint{MatchingTargetType: "SPECIFIC"}, ""},
 		{"valid matching target type OBJECT", PolicyEndpoint{MatchingTargetType: "OBJECT"}, ""},
 		{"invalid matching target type", PolicyEndpoint{MatchingTargetType: "INVALID"}, "matching_target_type must be one of"},


### PR DESCRIPTION
## Summary

The previous valid set `[ANY, IP, NETWORK, DOMAIN, REGION, PORT_GROUP, ADDRESS_GROUP]` was derived from external documentation. A direct probe against a UniFi v9 controller's `/proxy/network/v2/api/site/<site>/firewall-policies` endpoint returned a Jackson deserialization error listing the canonical enum:

> `Cannot deserialize value of type ... from String "DOMAIN": not one of the values accepted for Enum class: [APP, WEB, IP, APP_CATEGORY, NETWORK, IID, ANY, REGION]`

Three of the SDK's documented values (`DOMAIN`, `PORT_GROUP`, `ADDRESS_GROUP`) are not valid; four real values (`APP`, `APP_CATEGORY`, `IID`, `WEB`) were missing.

## Changes

- `PolicyEndpoint.Validate()` (`pkg/unifi/network_models.go`): replace the ` isOneOf(...)` list and the error string.
- Doc comment on `PolicyEndpoint` (`pkg/unifi/network_models.go:651`): update the valid-values list.
- Doc comment on `PolicyEndpointBuilder.MatchingTarget` setter (`pkg/unifi/builders.go:162`): update the valid-values list.
- `TestPolicyEndpointValidate`: add positive cases for `APP`, `APP_CATEGORY`, `IID`, `REGION`, `WEB`; add explicit negative cases for `DOMAIN`, `PORT_GROUP`, `ADDRESS_GROUP` to guard against re-introducing the wrong enum.

## Out of scope (deferred to follow-up PRs)

- **Carrier fields for `WEB`, `APP`, `APP_CATEGORY`, `IID`.** The values now pass validation, but `PolicyEndpoint` has no companion fields to actually populate a working policy in those modes (e.g. domain string for `WEB`, app/category/object IDs for the others). Adding them requires per-mode controller wire-format capture, which the original probe could only complete for one mode before harness restrictions blocked further attempts.
- **`TrafficRule.Validate()` and `TrafficRoute.Validate()`** (`pkg/unifi/network_models.go:1373`, `:1389`) currently list `[INTERNET, IP, DOMAIN, REGION, APP]`. Probably also wrong on v9 controllers, but no probe evidence exists yet — defer to a focused follow-up.

## Cross-repo paper trail

Sister change: [terraform-provider-unifi PR #8](https://github.com/resnickio/terraform-provider-unifi/pull/8) made the matching corrected-enum change in the provider's plan-time validator (already shipped as v0.9.0). This PR closes the remaining gap on the SDK side.

## Suggested release: v0.11.0

Removing accepted enum values is structurally breaking per SemVer, so a minor bump rather than patch. **No working code relied on the removed values** — the controller always rejected them — so the user-visible impact is zero, but the public-API surface change deserves the version signal.

## Test plan

- [x] `go vet ./... && go build ./...`
- [x] `go test ./pkg/unifi/... -count=1` — full SDK test suite passes (35.8s)
- [x] `go test -run TestPolicyEndpointValidate -v ./pkg/unifi/...` — all 5 new positive + 3 new negative cases pass